### PR TITLE
Detect CotentType of file use mime-types.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var crypto = require('crypto');
+var mime = require('mime-types');
 var AWS = require( 'aws-sdk' );
 
 function getFilename( req, file, cb ) {
@@ -74,12 +75,18 @@ S3Storage.prototype._handleFile = function _handleFile( req, file, cb ) {
 			}
 
 			var finalPath = path.join( destination, filename ),
-				size;
+				size,
+				contentType = mime.lookup(finalPath),
+				params = {
+					Key: finalPath,
+					Body: file.stream
+				};
 
-			self.s3obj.upload({
-				Key: finalPath,
-				Body: file.stream
-			})
+			if ( contentType ) {
+				params.ContentType = contentType;
+			}
+
+			self.s3obj.upload(params)
 			.on( 'httpUploadProgress', function( info){
 
 				if ( info.total ) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "aws-sdk": "^2.2.0",
     "crypto": "0.0.3",
+    "mime-types": "^2.1.7",
     "path": "^0.11.14"
   }
 }


### PR DESCRIPTION
`AWS.S3.upload` function can take another parameter to set the `ContentType` of the file. Right now, even though we are uploading an image, the file won't have the correct `ContentType` and therefore can cause issues using the file afterwards.

Adding the `mime-types` library will detect the mimetype automatically and set it if it is found
